### PR TITLE
Fix negateBits sign extension and add unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There are a few menu options available, by default they are all unchecked. You w
 This option will allow you to choose an Mtar file after the model has loaded. This allows you to view animations provided the bones match.
 
 ##### Highlight Missing Textures
-This option will addd a fuschia colour to textures that are missing so that they are easier to identify.
+This option will add a fuchsia colour to textures that are missing so that they are easier to identify.
 
 ##### Render Layer Map As Diffuse
 The game blends certain diffuse maps together, as I cannot do this in Noesis I have given the option to render the layer map as the main diffuse for the times when the layer map is supposed to be the main diffuse.

--- a/shader.h
+++ b/shader.h
@@ -106,7 +106,7 @@ int useShader002(MdnMaterial* material, noesisMaterial_t* noeMat, int maxTex, st
 inline
 int useShader003(MdnMaterial* material, noesisMaterial_t* noeMat, int maxTex, std::vector<uint32_t>& normalMaps) {
     shaderParams params = setParams(material->flag);
-    //params.noNorm = true; //sometimes has normal but not always
+    // params.noNorm = true; // some materials have a normal map, others do not
     int i = basicShader(material, noeMat, maxTex, normalMaps, params);
     if (i < maxTex) setLayer(noeMat, material->texture[i++], i); //layer texture goes here
     if (i < maxTex && params.hasEnv) setEnv(noeMat, material->texture[i++], i);

--- a/tests/negateBits_test.cpp
+++ b/tests/negateBits_test.cpp
@@ -1,0 +1,12 @@
+#include "util.h"
+#include <cassert>
+
+int main() {
+    // Positive value remains unchanged
+    assert(negateBits(0b01111111111, 11) == 1023);
+    // Value with sign bit set should be sign-extended
+    assert(negateBits(0b10000000000, 11) == -1024);
+    // All bits set should produce -1
+    assert(negateBits(0b11111111111, 11) == -1);
+    return 0;
+}

--- a/util.h
+++ b/util.h
@@ -1,8 +1,8 @@
 #pragma once
+#include <cstdint>
 
-inline
-int32_t negateBits(int32_t val, int numBits) {
+inline int32_t negateBits(int32_t val, int numBits) {
     int hi = numBits - 1;
-    int32_t mx = pow(2, hi);
+    int32_t mx = 1 << hi;
     return val >> hi ? val |= -mx : val;
 }


### PR DESCRIPTION
## Summary
- Correct `negateBits` to use integer bit shifting and include required header
- Clarify shader comment about normal maps
- Fix README typo for missing texture highlight
- Add unit test for `negateBits`

## Testing
- `g++ -std=c++17 -I. tests/negateBits_test.cpp -o tests/negateBits_test && ./tests/negateBits_test`


------
https://chatgpt.com/codex/tasks/task_e_68baa3b9ea4483219235dc4f635319e7